### PR TITLE
feat: re-export commonly used tokio utilities

### DIFF
--- a/eventually-postgres/Cargo.toml
+++ b/eventually-postgres/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["postgres", "postgresql", "database", "ddd", "event-sourcing"]
 
 [dependencies]
 eventually-core = { version = "0.4.0-alpha.1", path = "../eventually-core", features = ["full"] }
+eventually-util = { version = "0.4.0-alpha.1", path = "../eventually-util" }
 
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/eventually-postgres/src/subscriber.rs
+++ b/eventually-postgres/src/subscriber.rs
@@ -70,7 +70,7 @@ where
 
         let mut stream = futures::stream::poll_fn(move |cx| connection.poll_message(cx));
 
-        tokio::spawn(async move {
+        eventually_util::spawn(async move {
             while let Some(event) = stream.next().await {
                 let event = event.expect("subscriber connection failed");
 

--- a/eventually-test/Cargo.toml
+++ b/eventually-test/Cargo.toml
@@ -18,7 +18,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smol = { version = "0.3", features = ["tokio02"] }
 tide = "0.13"
-tokio = { version = "0.2", features = ["sync"] }
 tokio-postgres = "0.5"
 femme = "2.1.0"
 anyhow = "1.0"

--- a/eventually-test/src/lib.rs
+++ b/eventually-test/src/lib.rs
@@ -8,9 +8,8 @@ use std::sync::Arc;
 use eventually::aggregate::Optional;
 use eventually::inmemory::{EventStoreBuilder, Projector};
 use eventually::subscription::Transient as TransientSubscription;
+use eventually::sync::RwLock;
 use eventually::{AggregateRootBuilder, Repository};
-
-use tokio::sync::RwLock;
 
 use crate::config::Config;
 use crate::order::{OrderAggregate, TotalOrdersProjection};
@@ -50,7 +49,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // The projector will open its own running subscription, on which
     // it will receive all oldest and newest events as they come into the EventStore,
     // and it will progressively update the projection as events arrive.
-    tokio::spawn(async move { total_orders_projector.run().await.expect("should not fail") });
+    eventually::spawn(async move { total_orders_projector.run().await.expect("should not fail") });
 
     // Set up the HTTP router.
     let mut app = tide::new();

--- a/eventually-test/src/state.rs
+++ b/eventually-test/src/state.rs
@@ -2,9 +2,8 @@ use std::sync::Arc;
 
 use eventually::inmemory::EventStore;
 use eventually::optional::AsAggregate as Optional;
+use eventually::sync::RwLock;
 use eventually::{AggregateRootBuilder, Repository};
-
-use tokio::sync::RwLock;
 
 use crate::order;
 

--- a/eventually-util/src/inmemory/projector.rs
+++ b/eventually-util/src/inmemory/projector.rs
@@ -6,7 +6,7 @@ use eventually_core::subscription::Subscription;
 
 use futures::stream::StreamExt;
 
-use tokio::sync::RwLock;
+use crate::sync::RwLock;
 
 /// A `Projector` manages the state of a single [`Projection`]
 /// by opening a long-running stream of all events coming from the [`EventStore`].

--- a/eventually-util/src/lib.rs
+++ b/eventually-util/src/lib.rs
@@ -1,2 +1,5 @@
 pub mod inmemory;
 pub mod optional;
+pub mod sync;
+
+pub use tokio::spawn;

--- a/eventually-util/src/sync.rs
+++ b/eventually-util/src/sync.rs
@@ -1,0 +1,4 @@
+//! Module containing the asynchronous synchronization primitives
+//! the crate uses in the public API.
+
+pub use tokio::sync::RwLock;

--- a/eventually/src/lib.rs
+++ b/eventually/src/lib.rs
@@ -6,6 +6,7 @@ pub use eventually_core::repository::Repository;
 pub use eventually_core::store::EventStore;
 pub use eventually_core::subscription::EventSubscriber;
 pub use eventually_core::versioning::Versioned;
+pub use eventually_util::spawn;
 
 pub mod aggregate {
     pub use eventually_core::aggregate::*;
@@ -35,6 +36,10 @@ pub mod optional {
 
 pub mod inmemory {
     pub use eventually_util::inmemory::*;
+}
+
+pub mod sync {
+    pub use eventually_util::sync::*;
 }
 
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
Using re-exports is the first step to make `eventually` executor-independent, and drive the underlying executor utilized by a feature flag.