### PR TITLE
use nightly toolchain for linting and formatting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,11 +60,11 @@ jobs:
         - name: Checkout sources
           uses: actions/checkout@v2.3.3
 
-        - name: Install stable toolchain
+        - name: Install nightly toolchain
           uses: actions-rs/toolchain@v1
           with:
             profile: minimal
-            toolchain: stable
+            toolchain: nightly
             override: true
             components: rustfmt, clippy
 


### PR DESCRIPTION
makes sense to use the nightly toolchain for linting, though there's one caveat-

Clippy should really have a config file that specifies a MSRV (this project doesn't seem to specify one) in order to prevent it trying to apply lints that don't yet apply to stable (i've not seen this actually happen before, but in principle it's possible)