### PR TITLE
simplify 'EventSubscriber::subscribe_all'

### DIFF
--- a/eventually-core/src/subscription.rs
+++ b/eventually-core/src/subscription.rs
@@ -71,7 +71,7 @@ pub trait EventSubscriber {
     ///
     /// [`EventStore`]: ../store/trait.EventStore.html
     /// [`EventStream`]: type.EventStream.html
-    fn subscribe_all(&self) -> BoxFuture<Result<EventStream<Self>, Self::Error>>;
+    fn subscribe_all(&self) -> EventStream<Self>;
 }
 
 /// Stream of events returned by the [`Subscription::resume`] method.
@@ -212,12 +212,7 @@ where
             // and the subscription stream. Luckily, we can discard those by
             // keeping an internal state of the last processed sequence number,
             // and discard all those events that are found.
-            let subscription = self
-                .subscriber
-                .subscribe_all()
-                .await
-                .map_err(anyhow::Error::from)
-                .map_err(Error::Store)?;
+            let subscription = self.subscriber.subscribe_all();
 
             let one_off_stream = self
                 .store

--- a/eventually-postgres/src/subscriber.rs
+++ b/eventually-postgres/src/subscriber.rs
@@ -10,7 +10,6 @@ use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use futures::future::BoxFuture;
 use futures::stream::StreamExt;
 
 use eventually_core::store::Persisted;
@@ -133,12 +132,10 @@ where
     type Event = Event;
     type Error = SubscriberError;
 
-    fn subscribe_all(&self) -> BoxFuture<Result<EventStream<Self>>> {
-        Box::pin(async move {
-            Ok(BroadcastStream::new(self.tx.subscribe())
-                .filter_map(|r| async { r.ok() })
-                .boxed())
-        })
+    fn subscribe_all(&self) -> EventStream<Self> {
+        BroadcastStream::new(self.tx.subscribe())
+            .filter_map(|r| async { r.ok() })
+            .boxed()
     }
 }
 

--- a/eventually-postgres/src/subscription.rs
+++ b/eventually-postgres/src/subscription.rs
@@ -191,11 +191,7 @@ where
             // and the subscription stream. Luckily, we can discard those by
             // keeping an internal state of the last processed sequence number,
             // and discard all those events that are found.
-            let subscription = self
-                .subscriber
-                .subscribe_all()
-                .await
-                .map_err(Error::Subscriber)?;
+            let subscription = self.subscriber.subscribe_all();
 
             let one_off_stream = self
                 .store

--- a/eventually-postgres/tests/subscriber.rs
+++ b/eventually-postgres/tests/subscriber.rs
@@ -50,10 +50,7 @@ async fn subscribe_all_works() {
         .await
         .expect("failed to create event subscription");
 
-    let mut subscription = event_subscriber
-        .subscribe_all()
-        .await
-        .expect("failed to create subscription from event subscriber");
+    let mut subscription = event_subscriber.subscribe_all();
 
     event_store
         .append(

--- a/eventually-redis/tests/store.rs
+++ b/eventually-redis/tests/store.rs
@@ -39,8 +39,6 @@ async fn it_works() {
         builder_clone
             .build_subscriber::<String, Event>()
             .subscribe_all()
-            .await
-            .unwrap()
             .try_for_each(|_event| async { Ok(()) })
             .await
             .unwrap();


### PR DESCRIPTION
since `EventSubscriber::subscribe_all` returns a `TryFuture<TryStream<_, Error>, Error>` (ie they both have the same error type) this can be flattened into a `TryStream` alone.