### PR TITLE
Simplify 'Subscription' trait

### DIFF
--- a/eventually-core/src/subscription.rs
+++ b/eventually-core/src/subscription.rs
@@ -14,9 +14,6 @@ use futures::TryFutureExt;
 use crate::store::{EventStore, Persisted, Select};
 
 /// Stream of events returned by the [`EventSubscriber::subscribe_all`] method.
-///
-/// [`EventSubscriber::subscribe_all`]:
-/// trait.EventSubscriber.html#method.subscribe_all
 pub type EventStream<'a, S> = BoxStream<
     'a,
     Result<
@@ -35,19 +32,12 @@ pub type EventStream<'a, S> = BoxStream<
 /// of eventstore.com
 ///
 /// [_Volatile Subscription_]: https://eventstore.com/docs/getting-started/reading-subscribing-events/index.html#volatile-subscriptions
-/// [`EventStore`]: ../store/trait.EventStore.html
 pub trait EventSubscriber {
-    /// Type of the Source id, typically an [`AggregateId`].
-    ///
-    /// [`AggregateId`]: ../aggregate/type.AggregateId.html
+    /// Type of the Source id, typically an [`AggregateId`](super::aggregate::AggregateId).
     type SourceId: Eq;
 
     /// Event type stored in the [`EventStore`], typically an
-    /// [`Aggregate::Event`].
-    ///
-    /// [`Aggregate::Event`]:
-    /// ../aggregate/trait.Aggregate.html#associatedtype.Event
-    /// [`EventStore`]: ../store/trait.EventStore.html
+    /// [`Aggregate::Event`](super::aggregate::Aggregate::Event).
     type Event;
 
     /// Possible errors returned when receiving events from the notification
@@ -69,15 +59,10 @@ pub trait EventSubscriber {
     ///     // Do stuff with the received event...
     /// }
     /// ```
-    ///
-    /// [`EventStore`]: ../store/trait.EventStore.html
-    /// [`EventStream`]: type.EventStream.html
     fn subscribe_all(&self) -> EventStream<Self>;
 }
 
 /// Stream of events returned by the [`Subscription::resume`] method.
-///
-/// [`Subscription::resume`]: trait.Subscription.html#method.resume
 pub type SubscriptionStream<'a, S> = BoxStream<
     'a,
     Result<
@@ -88,16 +73,10 @@ pub type SubscriptionStream<'a, S> = BoxStream<
 
 /// A Subscription to an [`EventStream`] which can be "checkpointed":
 /// keeps a record of the latest message processed by itself using
-/// [`checkpoint`], and can resume working from such message by using the
-/// [`resume`].
-///
-/// [`EventStream`]: type.EventStream.html
-/// [`resume`]: trait.Subscription.html#method.resume
-/// [`checkpoint`]: trait.Subscription.html#method.checkpoint
+/// [`Subscription::checkpoint`], and can resume working from such message by using the
+/// [`Subscription::resume`].
 pub trait Subscription {
-    /// Type of the Source id, typically an [`AggregateId`].
-    ///
-    /// [`AggregateId`]: ../aggregate/type.AggregateId.html
+    /// Type of the Source id, typically an [`AggregateId`](super::aggregate::AggregateId).
     type SourceId: Eq;
 
     /// Event type stored in the [`EventStore`], typically an
@@ -105,7 +84,6 @@ pub trait Subscription {
     ///
     /// [`Aggregate::Event`]:
     /// ../aggregate/trait.Aggregate.html#associatedtype.Event
-    /// [`EventStore`]: ../store/trait.EventStore.html
     type Event;
 
     /// Possible errors returned when receiving events from the notification
@@ -114,9 +92,7 @@ pub trait Subscription {
 
     /// Resumes the current state of a `Subscription` by returning the
     /// [`EventStream`], starting from the last event processed by the
-    /// `Subscription`.
-    ///
-    /// [`EventStream`]: type.EventStream.html
+    /// [`Subscription`].
     fn resume(&self) -> SubscriptionStream<Self>;
 
     /// Saves the provided version (or sequence number) as the latest
@@ -125,19 +101,13 @@ pub trait Subscription {
 }
 
 /// Error type returned by a [`Transient`] Subscription.
-///
-/// [`Transient`]: struct.Transient.html
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error caused by the Subscription's [`EventStore`].
-    ///
-    /// [`EventStore`]: ../store/trait.EventStore.html
     #[error("error received while listening to the event stream from the store: {0}")]
     Store(#[source] anyhow::Error),
 
     /// Error caused by the Subscription's [`EventSubscriber`].
-    ///
-    /// [`EventSubscriber`]: trait.EventSubscriber.html
     #[error("error received while listening to the event stream subscription: {0}")]
     Subscription(#[source] anyhow::Error),
 }
@@ -145,10 +115,7 @@ pub enum Error {
 /// [`Subscription`] type which gets deleted once the process using it
 /// gets terminated.
 ///
-/// Useful for in-memory or one-off [`Projection`]s.
-///
-/// [`Subscription`]: trait.Subscription.html
-/// [`Projection`]: ../projection/trait.Projection.html
+/// Useful for in-memory or one-off [`Projection`](super::projection::Projection)s.
 pub struct Transient<Store, Subscriber> {
     store: Store,
     subscriber: Subscriber,
@@ -158,11 +125,6 @@ pub struct Transient<Store, Subscriber> {
 impl<Store, Subscriber> Transient<Store, Subscriber> {
     /// Creates a new [`Subscription`] using the specified [`EventStore`]
     /// and [`EventSubscriber`] to create the [`SubscriptionStream`] from.
-    ///
-    /// [`Subscription`]: trait.Subscription.html
-    /// [`EventStore`]: ../store/trait.EventStore.html
-    /// [`EventSubscriber`]: trait.EventSubscriber.html
-    /// [`SubscriptionStream`]: type.SubscriptionStream.html
     pub fn new(store: Store, subscriber: Subscriber) -> Self {
         Self {
             store,
@@ -172,10 +134,7 @@ impl<Store, Subscriber> Transient<Store, Subscriber> {
     }
 
     /// Specifies the sequence number of the `Event` the [`SubscriptionStream`]
-    /// should start from when calling [`run`].
-    ///
-    /// [`SubscriptionStream`]: type.SubscriptionStream.html
-    /// [`run`]: struct.Transient.html#method.run
+    /// should start from when calling [`Transient::resume`](Subscription::resume).
     pub fn from(self, sequence_number: u32) -> Self {
         self.last_sequence_number
             .store(sequence_number, Ordering::Relaxed);

--- a/eventually-core/src/subscription.rs
+++ b/eventually-core/src/subscription.rs
@@ -209,8 +209,7 @@ where
                     }
 
                     Ok(Some(event))
-                })
-                .boxed();
+                });
 
             Ok(stream)
         };

--- a/eventually-core/src/subscription.rs
+++ b/eventually-core/src/subscription.rs
@@ -8,7 +8,6 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::future::BoxFuture;
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
 use futures::TryFutureExt;
 
@@ -82,10 +81,7 @@ pub trait Subscription {
     type SourceId: Eq;
 
     /// Event type stored in the [`EventStore`], typically an
-    /// [`Aggregate::Event`].
-    ///
-    /// [`Aggregate::Event`]:
-    /// ../aggregate/trait.Aggregate.html#associatedtype.Event
+    /// [`Aggregate::Event`](super::aggregate::Aggregate::Event).
     type Event;
 
     /// Possible errors returned when receiving events from the notification

--- a/eventually-postgres/Cargo.toml
+++ b/eventually-postgres/Cargo.toml
@@ -33,6 +33,7 @@ tracing-futures = { version = "0.2", optional = true }
 bb8 = { version = "0.7.0" }
 bb8-postgres = { version = "0.7.0", features = ["with-serde_json-1"] }
 tokio-stream = { version = "0.1.4", features = ["sync"] }
+async-trait = "0.1.51"
 
 [dev-dependencies]
 testcontainers = "0.12"

--- a/eventually-postgres/tests/subscriber.rs
+++ b/eventually-postgres/tests/subscriber.rs
@@ -150,8 +150,6 @@ async fn persistent_subscription_works() {
 
     let events: Vec<Persisted<String, Event>> = subscription
         .resume()
-        .await
-        .expect("failed to resume subscription")
         .take(3)
         .try_collect()
         .await

--- a/eventually-util/src/inmemory/projector.rs
+++ b/eventually-util/src/inmemory/projector.rs
@@ -66,7 +66,7 @@ where
         #[cfg(feature = "with-tracing")]
         let projection_type = std::any::type_name::<P>();
 
-        let mut stream = self.subscription.resume().await?;
+        let mut stream = self.subscription.resume();
 
         while let Some(result) = stream.next().await {
             let event = result?;


### PR DESCRIPTION
similarly to #167, the `Future` returning a `Stream` can be flattened into a stream since they share the same error type