### PR TITLE
delegate 'clone' to calling code in 'AggregateRoot'

### DIFF
--- a/eventually-core/src/repository.rs
+++ b/eventually-core/src/repository.rs
@@ -115,7 +115,7 @@ where
                 |(version, state), event| async move {
                     // Always consider the max version number for the next version.
                     let new_version = std::cmp::max(event.version(), version);
-                    let state = T::apply(state, event.take()).map_err(Error::Aggregate)?;
+                    let state = T::apply(state, &event).map_err(Error::Aggregate)?;
 
                     Ok((new_version, state))
                 },

--- a/eventually-util/src/optional.rs
+++ b/eventually-util/src/optional.rs
@@ -39,11 +39,11 @@ pub trait Aggregate {
 
     /// Applies the specified [`Event`](Aggregate::Event) when the
     /// [`State`](Aggregate::State) is empty.
-    fn apply_first(event: Self::Event) -> Result<Self::State, Self::Error>;
+    fn apply_first(event: &Self::Event) -> Result<Self::State, Self::Error>;
 
     /// Applies the specified [`Event`](Aggregate::Event) on a pre-existing
     /// [`State`](Aggregate::State) value.
-    fn apply_next(state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error>;
+    fn apply_next(state: Self::State, event: &Self::Event) -> Result<Self::State, Self::Error>;
 
     /// Handles the specified [`Command`](Aggregate::Command)when the
     /// [`State`](Aggregate::State) is empty.
@@ -116,7 +116,7 @@ where
     type Error = A::Error;
 
     #[inline]
-    fn apply(state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error> {
+    fn apply(state: Self::State, event: &Self::Event) -> Result<Self::State, Self::Error> {
         match state {
             None => A::apply_first(event).map(Some),
             Some(state) => A::apply_next(state, event).map(Some),

--- a/eventually/src/lib.rs
+++ b/eventually/src/lib.rs
@@ -179,7 +179,7 @@ pub mod aggregate {
     //!     type Command = OrderCommand;
     //!     type Error = std::convert::Infallible; // This should be a meaningful error.
     //!
-    //!     fn apply(state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error> {
+    //!     fn apply(state: Self::State, event: &Self::Event) -> Result<Self::State, Self::Error> {
     //!         unimplemented!()
     //!     }
     //!


### PR DESCRIPTION
this change would avoid cloning the `Vec<Event>`, and instead allow the implementation to decide whether it's necessary to have an owned event to update the state (in many cases it might not be)