### PR TITLE
simplify 'EventStore' trait

### DIFF
--- a/eventually-postgres/src/subscription.rs
+++ b/eventually-postgres/src/subscription.rs
@@ -195,11 +195,7 @@ where
             // and discard all those events that are found.
             let subscription = self.subscriber.subscribe_all();
 
-            let one_off_stream = self
-                .store
-                .stream_all(Select::From(checkpoint))
-                .await
-                .map_err(Error::Store)?;
+            let one_off_stream = self.store.stream_all(Select::From(checkpoint));
 
             let stream = one_off_stream
                 .map_err(Error::Store)

--- a/eventually-postgres/tests/store.rs
+++ b/eventually-postgres/tests/store.rs
@@ -69,15 +69,11 @@ async fn different_types_can_share_id() {
         .expect("Failed appending ivents");
     let ivents: Vec<Persisted<String, Ivent>> = ivent_store
         .stream_all(Select::All)
-        .await
-        .expect("failed to create first stream")
         .try_collect()
         .await
         .expect("failed to collect ivents from subscription");
     let events: Vec<Persisted<String, Event>> = event_store
         .stream_all(Select::All)
-        .await
-        .expect("failed to create second stream")
         .try_collect()
         .await
         .expect("failed to collect events from subscription");
@@ -153,8 +149,6 @@ async fn stream_all_works() {
     // Select::All returns all the events.
     let events: Vec<Persisted<String, Event>> = event_store
         .stream_all(Select::All)
-        .await
-        .expect("failed to create first stream")
         .try_collect()
         .await
         .expect("failed to collect events from subscription");
@@ -187,8 +181,6 @@ async fn stream_all_works() {
     // in this case it will return only events coming from the second source.
     let events: Vec<Persisted<String, Event>> = event_store
         .stream_all(Select::From(3))
-        .await
-        .expect("failed to create second stream")
         .try_collect()
         .await
         .expect("failed to collect events from subscription");
@@ -252,8 +244,6 @@ async fn stream_works() {
     // Select::All returns all the events.
     let events: Vec<Persisted<String, Event>> = event_store
         .stream(source_id.to_owned(), Select::All)
-        .await
-        .expect("failed to create first stream")
         .try_collect()
         .await
         .expect("failed to collect events from subscription");
@@ -276,8 +266,6 @@ async fn stream_works() {
     // Select::From returns a slice of the events by their version.
     let events: Vec<Persisted<String, Event>> = event_store
         .stream(source_id.to_owned(), Select::From(3))
-        .await
-        .expect("failed to create second stream")
         .try_collect()
         .await
         .expect("failed to collect events from subscription");

--- a/eventually-redis/tests/store.rs
+++ b/eventually-redis/tests/store.rs
@@ -76,8 +76,6 @@ async fn it_works() {
         5000usize,
         store
             .stream_all(Select::All)
-            .await
-            .unwrap()
             .try_fold(0usize, |acc, _x| async move { Ok(acc + 1) })
             .await
             .unwrap()
@@ -89,8 +87,6 @@ async fn it_works() {
         3000usize,
         store
             .stream("test-source-1".to_owned(), Select::All)
-            .await
-            .unwrap()
             .try_fold(0usize, |acc, _x| async move { Ok(acc + 1) })
             .await
             .unwrap()
@@ -100,8 +96,6 @@ async fn it_works() {
         2000usize,
         store
             .stream("test-source-2".to_owned(), Select::All)
-            .await
-            .unwrap()
             .try_fold(0usize, |acc, _x| async move { Ok(acc + 1) })
             .await
             .unwrap()
@@ -185,8 +179,6 @@ async fn it_creates_persistent_subscription_successfully() {
     // Get size of committed events from the Event Store.
     let size = store
         .stream_all(Select::All)
-        .await
-        .unwrap()
         .try_fold(0usize, |acc, _x| async move { Ok(acc + 1) })
         .await
         .unwrap();

--- a/eventually/src/repository.rs
+++ b/eventually/src/repository.rs
@@ -126,8 +126,6 @@ where
     pub async fn get(&self, id: T::Id) -> Result<AggregateRoot<T>, T, Store> {
         self.store
             .stream(id.clone(), Select::All)
-            .await
-            .map_err(Error::Store)?
             // Re-map any errors from the Stream into a Repository error
             .map_err(Error::Store)
             // Try to fold all the Events into an Aggregate State.

--- a/eventually/src/repository.rs
+++ b/eventually/src/repository.rs
@@ -171,9 +171,13 @@ where
         feature = "with-tracing",
         tracing::instrument(name = "Repository::add", skip(self))
     )]
-    async fn append_events(&mut self, id: T::Id, version: u32, events: Vec<T::Event>) -> Result<u32, T, Store> {
-        self
-            .store
+    async fn append_events(
+        &mut self,
+        id: T::Id,
+        version: u32,
+        events: Vec<T::Event>,
+    ) -> Result<u32, T, Store> {
+        self.store
             .append(id, Expected::Exact(version), events)
             .await
             .map_err(Error::Store)

--- a/eventually/src/subscription.rs
+++ b/eventually/src/subscription.rs
@@ -234,9 +234,8 @@ where
                 .stream_all(Select::From(
                     self.last_sequence_number.load(Ordering::Relaxed),
                 ))
-                .await
                 .map_err(anyhow::Error::from)
-                .map_err(Error::Subscription)?;
+                .map_err(Error::Subscription);
 
             let stream = one_off_stream
                 .map_err(anyhow::Error::from)


### PR DESCRIPTION
i've marked this as a draft for now, since it doesn't have parity with the original implementation- I've stripped out some of the `tracing` from the original and not replaced it in this implementation. It wasn't totally clear to me where it should go, so i might need some input.

while i was doing it i thought that maybe implementing tracing in the trait implementation maybe isn't the best place for it anyway. It would be better if the logging was added to the code that calls the trait, so that the logging is unified and consistent regardless of the actual implementation of the trait. Interested to hear your thoughts