### PR TITLE
avoid panics on integer cast and give space for timestamps

### DIFF
--- a/eventually-core/src/aggregate.rs
+++ b/eventually-core/src/aggregate.rs
@@ -116,7 +116,7 @@ where
     /// Builds a new [`AggregateRoot`] instance for the specified Aggregate
     /// with a specified [`State`](Aggregate::State) value.
     #[inline]
-    pub fn build_with_state(&self, id: T::Id, version: u32, state: T::State) -> AggregateRoot<T> {
+    pub fn build_with_state(&self, id: T::Id, version: i64, state: T::State) -> AggregateRoot<T> {
         AggregateRoot {
             id,
             version,
@@ -150,7 +150,7 @@ where
     T: Aggregate + 'static,
 {
     id: T::Id,
-    version: u32,
+    version: i64,
 
     #[cfg_attr(feature = "serde", serde(flatten))]
     state: T::State,
@@ -177,7 +177,7 @@ where
     T: Aggregate,
 {
     #[inline]
-    fn version(&self) -> u32 {
+    fn version(&self) -> i64 {
         self.version
     }
 }
@@ -209,7 +209,7 @@ where
 
     /// Returns a new [`AggregateRoot`] having the specified version.
     #[inline]
-    pub(crate) fn with_version(mut self, version: u32) -> Self {
+    pub(crate) fn with_version(mut self, version: i64) -> Self {
         self.version = version;
         self
     }

--- a/eventually-core/src/store.rs
+++ b/eventually-core/src/store.rs
@@ -20,7 +20,7 @@ pub enum Select {
     /// To return a slice of the [`EventStream`], starting from
     /// those [`Event`](EventStore::Event)s with version **greater or equal**
     /// than the one specified in this variant.
-    From(u32),
+    From(i64),
 }
 
 /// Specifies the optimistic locking level when performing
@@ -36,7 +36,7 @@ pub enum Expected {
     /// Append events only if the current version of the
     /// [`Aggregate`](super::aggregate::Aggregate) is the one specified by
     /// the value provided here.
-    Exact(u32),
+    Exact(i64),
 }
 
 /// Stream type returned by the [`EventStore::stream`] method.
@@ -106,7 +106,7 @@ pub trait EventStore {
         source_id: Self::SourceId,
         version: Expected,
         events: Vec<Self::Event>,
-    ) -> BoxFuture<Result<u32, Self::Error>>;
+    ) -> BoxFuture<Result<i64, Self::Error>>;
 
     /// Streams a list of [`Event`](EventStore::Event)s from the [`EventStore`]
     /// back to the application, by specifying the desired
@@ -152,15 +152,15 @@ pub trait EventStore {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Persisted<SourceId, T> {
     source_id: SourceId,
-    version: u32,
-    sequence_number: u32,
+    version: i64,
+    sequence_number: i64,
     #[cfg_attr(feature = "serde", serde(flatten))]
     event: T,
 }
 
 impl<SourceId, T> Versioned for Persisted<SourceId, T> {
     #[inline]
-    fn version(&self) -> u32 {
+    fn version(&self) -> i64 {
         self.version
     }
 }
@@ -183,7 +183,7 @@ impl<SourceId, T> Persisted<SourceId, T> {
 
     /// Returns the event sequence number.
     #[inline]
-    pub fn sequence_number(&self) -> u32 {
+    pub fn sequence_number(&self) -> i64 {
         self.sequence_number
     }
 
@@ -222,7 +222,7 @@ pub mod persistent {
         /// Specifies the [`Persisted`](super::Persisted) version and moves to
         /// the next builder state.
         #[inline]
-        pub fn version(self, value: u32) -> EventBuilderWithVersion<SourceId, T> {
+        pub fn version(self, value: i64) -> EventBuilderWithVersion<SourceId, T> {
             EventBuilderWithVersion {
                 version: value,
                 event: self.event,
@@ -233,7 +233,7 @@ pub mod persistent {
         /// Specifies the [`Persisted`](super::Persisted) sequence number and
         /// moves to the next builder state.
         #[inline]
-        pub fn sequence_number(self, value: u32) -> EventBuilderWithSequenceNumber<SourceId, T> {
+        pub fn sequence_number(self, value: i64) -> EventBuilderWithSequenceNumber<SourceId, T> {
             EventBuilderWithSequenceNumber {
                 sequence_number: value,
                 event: self.event,
@@ -245,7 +245,7 @@ pub mod persistent {
     /// Next step in creating a new [`Persisted`](super::Persisted) carrying an
     /// Event value and its version.
     pub struct EventBuilderWithVersion<SourceId, T> {
-        version: u32,
+        version: i64,
         event: T,
         source_id: SourceId,
     }
@@ -254,7 +254,7 @@ pub mod persistent {
         /// Specifies the [`Persisted`](super::Persisted) sequence number and
         /// moves to the next builder state.
         #[inline]
-        pub fn sequence_number(self, value: u32) -> super::Persisted<SourceId, T> {
+        pub fn sequence_number(self, value: i64) -> super::Persisted<SourceId, T> {
             super::Persisted {
                 version: self.version,
                 event: self.event,
@@ -267,7 +267,7 @@ pub mod persistent {
     /// Next step in creating a new [`Persisted`](super::Persisted) carrying an
     /// Event value and its sequence number.
     pub struct EventBuilderWithSequenceNumber<SourceId, T> {
-        sequence_number: u32,
+        sequence_number: i64,
         event: T,
         source_id: SourceId,
     }
@@ -276,7 +276,7 @@ pub mod persistent {
         /// Specifies the [`Persisted`](super::Persisted) version and moves to
         /// the next builder state.
         #[inline]
-        pub fn version(self, value: u32) -> super::Persisted<SourceId, T> {
+        pub fn version(self, value: i64) -> super::Persisted<SourceId, T> {
             super::Persisted {
                 version: value,
                 event: self.event,

--- a/eventually-core/src/subscription.rs
+++ b/eventually-core/src/subscription.rs
@@ -4,7 +4,7 @@
 //! [`EventStore`]: ../store/trait.EventStore.html
 
 use std::error::Error as StdError;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 
 use futures::future::{ok, BoxFuture, FutureExt};
@@ -120,7 +120,7 @@ pub trait Subscription {
 
     /// Saves the provided version (or sequence number) as the latest
     /// version processed.
-    fn checkpoint(&self, version: u32) -> BoxFuture<Result<(), Self::Error>>;
+    fn checkpoint(&self, version: i64) -> BoxFuture<Result<(), Self::Error>>;
 }
 
 /// Error type returned by a [`Transient`] Subscription.
@@ -151,7 +151,7 @@ pub enum Error {
 pub struct Transient<Store, Subscriber> {
     store: Store,
     subscriber: Subscriber,
-    last_sequence_number: Arc<AtomicU32>,
+    last_sequence_number: Arc<AtomicI64>,
 }
 
 impl<Store, Subscriber> Transient<Store, Subscriber> {
@@ -175,7 +175,7 @@ impl<Store, Subscriber> Transient<Store, Subscriber> {
     ///
     /// [`SubscriptionStream`]: type.SubscriptionStream.html
     /// [`run`]: struct.Transient.html#method.run
-    pub fn from(self, sequence_number: u32) -> Self {
+    pub fn from(self, sequence_number: i64) -> Self {
         self.last_sequence_number
             .store(sequence_number, Ordering::Relaxed);
 
@@ -256,7 +256,7 @@ where
         })
     }
 
-    fn checkpoint(&self, version: u32) -> BoxFuture<Result<(), Self::Error>> {
+    fn checkpoint(&self, version: i64) -> BoxFuture<Result<(), Self::Error>> {
         // Checkpointing happens in memory on the atomic sequence number checkpoint.
         self.last_sequence_number.store(version, Ordering::Relaxed);
         ok(()).boxed()

--- a/eventually-core/src/versioning.rs
+++ b/eventually-core/src/versioning.rs
@@ -4,7 +4,7 @@
 /// Data type that carries a version for Optimistic Concurrency Control.
 pub trait Versioned {
     /// Current version of the data.
-    fn version(&self) -> u32;
+    fn version(&self) -> i64;
 }
 
 impl<T> Versioned for Option<T>
@@ -12,7 +12,7 @@ where
     T: Versioned,
 {
     #[inline]
-    fn version(&self) -> u32 {
+    fn version(&self) -> i64 {
         self.as_ref().map(Versioned::version).unwrap_or_default()
     }
 }

--- a/eventually-postgres/src/store.rs
+++ b/eventually-postgres/src/store.rs
@@ -273,7 +273,7 @@ where
         id: Self::SourceId,
         version: Expected,
         events: Vec<Self::Event>,
-    ) -> BoxFuture<Result<u32>> {
+    ) -> BoxFuture<Result<i64>> {
         #[cfg(feature = "with-tracing")]
         let span = tracing::info_span!(
             "EventStore::append",
@@ -306,7 +306,7 @@ where
             let row = client.query_one(APPEND, params).await?;
 
             let id: i32 = row.try_get("aggregate_version")?;
-            Ok(id as u32)
+            Ok(id as i64)
         };
 
         #[cfg(feature = "with-tracing")]
@@ -351,8 +351,8 @@ where
 
         let fut = async move {
             let from = match select {
-                Select::All => 0i64,
-                Select::From(v) => v as i64,
+                Select::All => 0,
+                Select::From(v) => v,
             };
 
             let params: Params = &[&self.type_name, &from];
@@ -462,8 +462,8 @@ where
                     .map_err(Error::DecodeEvent)?;
 
                 Ok(Persisted::from(id, event)
-                    .version(version as u32)
-                    .sequence_number(sequence_number as u32))
+                    .version(version as i64)
+                    .sequence_number(sequence_number))
             })
             .boxed())
     }

--- a/eventually-postgres/src/subscriber.rs
+++ b/eventually-postgres/src/subscriber.rs
@@ -146,8 +146,8 @@ where
 #[derive(Debug, Deserialize)]
 struct NotificationPayload<Event> {
     source_id: String,
-    version: u32,
-    sequence_number: u32,
+    version: i64,
+    sequence_number: i64,
     event: Event,
 }
 

--- a/eventually-redis/src/store.rs
+++ b/eventually-redis/src/store.rs
@@ -105,7 +105,7 @@ where
         id: Self::SourceId,
         version: Expected,
         events: Vec<Self::Event>,
-    ) -> BoxFuture<StoreResult<u32>> {
+    ) -> BoxFuture<StoreResult<i64>> {
         let fut = async move {
             let events = events
                 .iter()
@@ -118,7 +118,7 @@ where
                 .key(id.to_string())
                 .arg(match version {
                     Expected::Any => -1,
-                    Expected::Exact(v) => v as i64,
+                    Expected::Exact(v) => v,
                 })
                 .arg(events)
                 .invoke_async(&mut self.conn)
@@ -155,7 +155,7 @@ where
                     let event: Event =
                         serde_json::from_slice(&event).map_err(StoreError::DecodeJSON)?;
 
-                    let sequence_number: u32 = entry
+                    let sequence_number = entry
                         .get("sequence_number")
                         .ok_or(StoreError::NoKey("sequence_number"))?;
 
@@ -163,7 +163,7 @@ where
 
                     Ok(Persisted::from(id, event)
                         .sequence_number(sequence_number)
-                        .version(version as u32))
+                        .version(version as i64))
                 })
                 .boxed())
         };

--- a/eventually-redis/src/stream.rs
+++ b/eventually-redis/src/stream.rs
@@ -63,14 +63,14 @@ where
         let event: Vec<u8> = entry.get("event").ok_or(ToPersistedError::NoKey("event"))?;
         let event: Event = serde_json::from_slice(&event).map_err(ToPersistedError::DecodeJSON)?;
 
-        let version: u32 = entry
+        let version = entry
             .get("version")
             .ok_or(ToPersistedError::NoKey("version"))?;
 
         let sequence_number = parse_version(&entry.id);
 
         Ok(Persisted::from(source_id, event)
-            .sequence_number(sequence_number as u32)
+            .sequence_number(sequence_number as i64)
             .version(version))
     }
 }

--- a/eventually-redis/src/subscriber.rs
+++ b/eventually-redis/src/subscriber.rs
@@ -76,8 +76,8 @@ where
         #[derive(Deserialize)]
         struct SubscribeMessage<Event> {
             source_id: String,
-            sequence_number: u32,
-            version: u32,
+            sequence_number: i64,
+            version: i64,
             event: Event,
         }
 

--- a/eventually-redis/src/subscription.rs
+++ b/eventually-redis/src/subscription.rs
@@ -39,12 +39,12 @@ pub enum SubscriptionError {
     /// Error returned when failed to acknowledge one Redis message
     /// using `XACK` command, due to an error occurred on Redis server.
     #[error("failed to checkpoint subscription due to Redis error: version {0}, {1}")]
-    CheckpointFromRedis(u32, #[source] RedisError),
+    CheckpointFromRedis(i64, #[source] RedisError),
 
     /// Error returned when Redis didn't acknowledge an `XACK` command,
     /// likely due to an incorrect version number provided.
     #[error("checkpoint subscription not acknowledged by Redis, check the version: version {0}")]
-    Checkpoint(u32),
+    Checkpoint(i64),
 }
 
 /// [`Subscription`] implementation with persistent state over a Redis
@@ -123,7 +123,7 @@ where
         Box::pin(fut)
     }
 
-    fn checkpoint(&self, version: u32) -> BoxFuture<SubscriptionResult<()>> {
+    fn checkpoint(&self, version: i64) -> BoxFuture<SubscriptionResult<()>> {
         let fut = async move {
             let mut conn = self.conn.clone();
             let stream_version = format!("{}-1", version);


### PR DESCRIPTION
## Problem

When going through the code I noticed that there are quite a few places where the application could crash due to type casting overflow.

"In theory" this is ok in current versions, because both version and sequence are serials starting at 0. However, this is very constrained for other cases.

I can think of at least two scenarios where this approach is limiting:
- The postgres store already saves sequences as BIGINT and so the amount of events that it could safe for now is 2147483647. More events than that, and the casting from i64 (usual equivalent of BIGINT in Rust) to i32 may overflow
- I'm writing an event store for TimescaleDB where versions are stored as epoch time in nanoseconds. This is already reaching the limit of what this crate can do in terms of type casting

## Solution

This PR removes most instances where casting could crash and allows plenty of room for event stores to do their data modelling as they need to

## Caveats

There are a few instances in the postgres store where the columns are defined as `INTEGER` and therefore there is still some casting from Rust's i64 to i32