### PR TITLE
rename aggregate builder to factory

### DIFF
--- a/eventually-core/src/aggregate.rs
+++ b/eventually-core/src/aggregate.rs
@@ -83,16 +83,16 @@ pub trait AggregateExt: Aggregate {
 
 impl<T> AggregateExt for T where T: Aggregate {}
 
-/// Builder type for new [`AggregateRoot`] instances.
+/// Factory type for new [`AggregateRoot`] instances.
 #[derive(Clone)]
-pub struct AggregateRootBuilder<T>
+pub struct AggregateRootFactory<T>
 where
     T: Aggregate,
 {
     aggregate: T,
 }
 
-impl<T> From<T> for AggregateRootBuilder<T>
+impl<T> From<T> for AggregateRootFactory<T>
 where
     T: Aggregate,
 {
@@ -102,7 +102,7 @@ where
     }
 }
 
-impl<T> AggregateRootBuilder<T>
+impl<T> AggregateRootFactory<T>
 where
     T: Aggregate + Clone,
 {
@@ -139,9 +139,9 @@ where
 /// ## Initialize
 ///
 /// An [`AggregateRoot`] can only be initialized using the
-/// [`AggregateRootBuilder`].
+/// [`AggregateRootFactory`].
 ///
-/// Check [`AggregateRootBuilder::build`] for more information.
+/// Check [`AggregateRootFactory::build`] for more information.
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize))]

--- a/eventually-core/src/repository.rs
+++ b/eventually-core/src/repository.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 
 use futures::stream::TryStreamExt;
 
-use crate::aggregate::{Aggregate, AggregateRoot, AggregateRootBuilder};
+use crate::aggregate::{Aggregate, AggregateRoot, AggregateRootFactory};
 use crate::store::{EventStore, Expected, Select};
 use crate::versioning::Versioned;
 
@@ -58,7 +58,7 @@ where
     T: Aggregate + Clone + 'static,
     Store: EventStore<SourceId = T::Id, Event = T::Event>,
 {
-    builder: AggregateRootBuilder<T>,
+    factory: AggregateRootFactory<T>,
     store: Store,
 }
 
@@ -73,8 +73,8 @@ where
     /// [`EventStore`]: ../store/trait.EventStore.html
     /// [`Aggregate`]: ../aggregate/trait.Aggregate.html
     #[inline]
-    pub fn new(builder: AggregateRootBuilder<T>, store: Store) -> Self {
-        Repository { builder, store }
+    pub fn new(factory: AggregateRootFactory<T>, store: Store) -> Self {
+        Repository { factory, store }
     }
 }
 
@@ -123,7 +123,7 @@ where
             .await
             // ...and map the State to a new AggregateRoot only if there is
             // at least one Event coming from the Event Stream.
-            .map(|(version, state)| self.builder.build_with_state(id, version, state))
+            .map(|(version, state)| self.factory.build_with_state(id, version, state))
     }
 
     /// Adds a new [`State`] of the [`Aggregate`] into the `Repository`,

--- a/eventually/src/lib.rs
+++ b/eventually/src/lib.rs
@@ -52,7 +52,7 @@
 //! [`Projection`]: trait.Projection.html
 
 pub use eventually_core::aggregate::{
-    Aggregate, AggregateExt, AggregateId, AggregateRoot, AggregateRootBuilder,
+    Aggregate, AggregateExt, AggregateId, AggregateRoot, AggregateRootFactory,
 };
 pub use eventually_core::projection::Projection;
 pub use eventually_core::repository::Repository;
@@ -223,7 +223,7 @@ pub mod aggregate {
     //! by managing its [`State`] and the access to submit commands.
     //!
     //! Access to an [`AggregateRoot`] is obtainable in two ways:
-    //! 1. Through the [`AggregateRootBuilder`], useful for testing
+    //! 1. Through the [`AggregateRootFactory`], useful for testing
     //! 2. Through a [`Repository`] instance
     //!
     //! More on the [`Repository`] in the [module-level
@@ -240,7 +240,7 @@ pub mod aggregate {
     //! [`as_aggregate`]: trait.Optional.html#method.as_aggregate
     //! [`optional::AsAggregate`]: ../optional/struct.AsAggregate.html
     //! [`AggregateRoot`]: struct.AggregateRoot.html
-    //! [`AggregateRootBuilder`]: struct.AggregateRootBuilder.html
+    //! [`AggregateRootFactory`]: struct.AggregateRootFactory.html
     //! [`Repository`]: struct.Repository.html
 
     pub use eventually_core::aggregate::*;


### PR DESCRIPTION
this pull request renames the aggregate builder to aggregate factory.

'builder' has a specific meaning in rust. It usually refers to objects that have a fluent API for constructing a new object. It's the functional alternative to constructor overloading.

the `AggregateRootBuilder` *does* generate new `AggregateRoot`s, but doesn't have the fluent interface of a typical builder. I think conceptually 'Factory' might capture the intent a little better. Might be being a bit nitpicky here...