### PR TITLE
Apply stricter lint configuration

### DIFF
--- a/eventually-postgres/src/lib.rs
+++ b/eventually-postgres/src/lib.rs
@@ -57,9 +57,9 @@ pub mod store;
 pub mod subscriber;
 pub mod subscription;
 
-pub use store::*;
-pub use subscriber::*;
-pub use subscription::*;
+pub use store::{EventStore, EventStoreBuilder};
+pub use subscriber::EventSubscriber;
+pub use subscription::PersistentBuilder;
 
 use tokio_postgres::types::ToSql;
 

--- a/eventually-postgres/src/store.rs
+++ b/eventually-postgres/src/store.rs
@@ -5,7 +5,6 @@
 
 use std::convert::TryFrom;
 use std::fmt::{Debug, Display};
-use std::ops::DerefMut;
 
 use eventually::aggregate::{Aggregate, AggregateId};
 use eventually::store::{AppendError, EventStream, Expected, Persisted, Select};
@@ -129,7 +128,7 @@ impl EventStoreBuilder {
     {
         let mut connection = pool.get().await?;
         embedded::migrations::runner()
-            .run_async(connection.deref_mut())
+            .run_async(&mut *connection)
             .await?;
 
         Ok(Self { inner: () })
@@ -290,7 +289,7 @@ where
                 .map_err(Error::EncodeEvents)?;
 
             let (version, check) = match version {
-                Expected::Any => (0i32, false),
+                Expected::Any => (0_i32, false),
                 Expected::Exact(v) => (v as i32, true),
             };
 
@@ -325,7 +324,7 @@ where
 
         let fut = async move {
             let from = match select {
-                Select::All => 0i32,
+                Select::All => 0_i32,
                 Select::From(v) => v as i32,
             };
 
@@ -351,8 +350,8 @@ where
 
         let fut = async move {
             let from = match select {
-                Select::All => 0i64,
-                Select::From(v) => v as i64,
+                Select::All => 0_i64,
+                Select::From(v) => i64::from(v),
             };
 
             let params: Params = &[&self.type_name, &from];

--- a/eventually-postgres/src/subscription.rs
+++ b/eventually-postgres/src/subscription.rs
@@ -205,7 +205,7 @@ where
                 .map_err(Error::Store)
                 .chain(subscription.map_err(Error::Subscriber))
                 .try_filter_map(move |event| async move {
-                    let event_sequence_number = event.sequence_number() as i64;
+                    let event_sequence_number = i64::from(event.sequence_number());
                     let expected_sequence_number =
                         self.last_sequence_number.load(Ordering::Relaxed);
 
@@ -230,7 +230,7 @@ where
     }
 
     async fn checkpoint(&self, version: u32) -> Result<(), Self::Error> {
-        let params: Params = &[&self.name, &self.store.type_name, &(version as i64)];
+        let params: Params = &[&self.name, &self.store.type_name, &(i64::from(version))];
 
         #[cfg(feature = "with-tracing")]
         tracing::trace!(
@@ -248,7 +248,7 @@ where
             .map_err(Error::Checkpoint)?;
 
         self.last_sequence_number
-            .store(version as i64, Ordering::Relaxed);
+            .store(i64::from(version), Ordering::Relaxed);
 
         Ok(())
     }

--- a/eventually-redis/src/lib.rs
+++ b/eventually-redis/src/lib.rs
@@ -26,9 +26,9 @@ mod stream;
 mod subscriber;
 mod subscription;
 
-pub use store::*;
-pub use subscriber::*;
-pub use subscription::*;
+pub use store::EventStore;
+pub use subscriber::EventSubscriber;
+pub use subscription::PersistentSubscription;
 
 use redis::RedisResult;
 

--- a/eventually-redis/src/store.rs
+++ b/eventually-redis/src/store.rs
@@ -93,8 +93,7 @@ impl<Id, Event> eventually::EventStore for EventStore<Id, Event>
 where
     Id: TryFrom<String> + Display + Eq + Clone + Send + Sync,
     <Id as TryFrom<String>>::Error: std::error::Error + Send + Sync + 'static,
-    Event: Serialize + Send + Sync,
-    for<'de> Event: Deserialize<'de>,
+    for<'de> Event: Serialize + Send + Sync + Deserialize<'de>,
 {
     type SourceId = Id;
     type Event = Event;

--- a/eventually-redis/src/store.rs
+++ b/eventually-redis/src/store.rs
@@ -117,7 +117,7 @@ where
                 .key(id.to_string())
                 .arg(match version {
                     Expected::Any => -1,
-                    Expected::Exact(v) => v as i64,
+                    Expected::Exact(v) => i64::from(v),
                 })
                 .arg(events)
                 .invoke_async(&mut self.conn)
@@ -134,7 +134,7 @@ where
         select: Select,
     ) -> BoxFuture<StoreResult<StoreEventStream<Self>>> {
         let fut = async move {
-            let stream_name = format!("{}.{}", self.stream_name, id.to_string());
+            let stream_name = format!("{}.{}", self.stream_name, id);
 
             let paginator = stream::into_xrange_stream(
                 self.conn.clone(),

--- a/eventually-redis/src/subscriber.rs
+++ b/eventually-redis/src/subscriber.rs
@@ -65,8 +65,7 @@ impl<Id, Event> eventually::subscription::EventSubscriber for EventSubscriber<Id
 where
     Id: TryFrom<String> + Eq + Send + Sync,
     <Id as TryFrom<String>>::Error: std::error::Error + Send + Sync + 'static,
-    Event: Send + Sync,
-    for<'de> Event: Deserialize<'de>,
+    for<'de> Event: Deserialize<'de> + Send + Sync,
 {
     type SourceId = Id;
     type Event = Event;

--- a/eventually-redis/src/subscriber.rs
+++ b/eventually-redis/src/subscriber.rs
@@ -11,11 +11,6 @@ use redis::RedisError;
 
 use serde::Deserialize;
 
-/// Result returning the crate [`SubscriberError`] type.
-///
-/// [`SubscriberError`]: enum.Error.html
-pub type SubscriberResult<T> = Result<T, SubscriberError>;
-
 /// Error types returned by the [`eventually::EventSubscriber`] implementation
 /// on the [`EventSubscriber`] type.
 ///

--- a/eventually-redis/src/subscription.rs
+++ b/eventually-redis/src/subscription.rs
@@ -93,8 +93,7 @@ impl<Id, Event> Subscription for PersistentSubscription<Id, Event>
 where
     Id: TryFrom<String> + Debug + Eq + Clone + Send + Sync,
     <Id as TryFrom<String>>::Error: std::error::Error + Send + Sync + 'static,
-    Event: Debug + Send + Sync,
-    for<'de> Event: Deserialize<'de>,
+    for<'de> Event: Deserialize<'de> + Debug + Send + Sync,
 {
     type SourceId = Id;
     type Event = Event;

--- a/eventually/src/store.rs
+++ b/eventually/src/store.rs
@@ -206,7 +206,7 @@ impl<SourceId, T> Persisted<SourceId, T> {
     /// provided Event value.
     #[inline]
     pub fn from(source_id: SourceId, event: T) -> persistent::EventBuilder<SourceId, T> {
-        persistent::EventBuilder { source_id, event }
+        persistent::EventBuilder { event, source_id }
     }
 
     /// Returns the event sequence number.
@@ -242,7 +242,7 @@ pub mod persistent {
         #[inline]
         fn from(value: (SourceId, T)) -> Self {
             let (source_id, event) = value;
-            Self { source_id, event }
+            Self { event, source_id }
         }
     }
 

--- a/eventually/src/subscription.rs
+++ b/eventually/src/subscription.rs
@@ -183,7 +183,7 @@ impl<Store, Subscriber> Transient<Store, Subscriber> {
         Self {
             store,
             subscriber,
-            last_sequence_number: Default::default(),
+            last_sequence_number: Arc::default(),
         }
     }
 

--- a/eventually/src/util.rs
+++ b/eventually/src/util.rs
@@ -1,13 +1,6 @@
 //! Collection of utilities that extends or implements some of the traits
 //! found in this crate.
 
-#[deny(
-    clippy::all,
-    missing_docs,
-    unsafe_code,
-    unused_qualifications,
-    trivial_casts
-)]
 pub mod inmemory;
 pub mod optional;
 pub mod sync;

--- a/eventually/src/util.rs
+++ b/eventually/src/util.rs
@@ -1,6 +1,13 @@
 //! Collection of utilities that extends or implements some of the traits
 //! found in this crate.
 
+#[deny(
+    clippy::all,
+    missing_docs,
+    unsafe_code,
+    unused_qualifications,
+    trivial_casts
+)]
 pub mod inmemory;
 pub mod optional;
 pub mod sync;

--- a/eventually/src/util/inmemory/mod.rs
+++ b/eventually/src/util/inmemory/mod.rs
@@ -3,5 +3,5 @@
 mod projector;
 mod store;
 
-pub use projector::*;
-pub use store::*;
+pub use projector::Projector;
+pub use store::{ConflictError, EventStore, EventStoreBuilder, LaggedError};

--- a/eventually/src/util/optional.rs
+++ b/eventually/src/util/optional.rs
@@ -103,8 +103,7 @@ impl<A> From<A> for IntoAggregate<A> {
 #[async_trait]
 impl<A> crate::aggregate::Aggregate for IntoAggregate<A>
 where
-    A: Aggregate,
-    A: Send + Sync,
+    A: Aggregate + Send + Sync,
     A::Id: Send + Sync,
     A::Command: Send + Sync,
     A::State: Send + Sync,


### PR DESCRIPTION
What it says on the tin ;)

this PR
- moves the compiler flags from a cargo config file to inline compiler flags (which i believe is generally preferred). 
- adds the `deny(clippy::all)` lint flag, which is a stricter linting configuration than was applied previously. this necessitated a couple of code changes to appease the stricter lint.
- fixes a couple of `clippy::pedantic` lints (though i've not enabled the flag for this)