### PR TITLE
[v0.5.0][eventually] Introduce message::Payload trait

### DIFF
--- a/eventually/src/event.rs
+++ b/eventually/src/event.rs
@@ -8,8 +8,9 @@ use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    message,
+    message::Message,
     version::{ConflictError, Version},
-    Message,
 };
 
 /// An Event is a [Message] carring the information about a Domain Event,
@@ -19,7 +20,10 @@ pub type Event<T> = Message<T>;
 
 /// An [Event] that has been persisted to the Event [Store].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Persisted<Id, Evt> {
+pub struct Persisted<Id, Evt>
+where
+    Evt: message::Payload,
+{
     /// The id of the Event Stream the persisted Event belongs to.
     pub stream_id: Id,
 
@@ -34,9 +38,6 @@ pub struct Persisted<Id, Evt> {
     /// The actual Domain Event carried by this envelope.
     pub payload: Event<Evt>,
 }
-
-/// Shortcut type to represent multiple [Persisted] Events.
-pub type PersistedEvents<Id, Evt> = Vec<Persisted<Id, Evt>>;
 
 /// Specifies the slice of the Event Stream to select when calling [`Store::stream`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,7 +81,7 @@ pub trait Store: Send + Sync {
 
     /// The type containing all Domain Events recorded by the Event Store.
     /// Typically, this parameter should be an `enum`.
-    type Event: Send + Sync;
+    type Event: message::Payload + Send + Sync;
 
     /// The error type returned by the Store during a [`stream`] call.
     type StreamError: Send + Sync;

--- a/eventually/src/lib.rs
+++ b/eventually/src/lib.rs
@@ -5,69 +5,7 @@
 pub mod aggregate;
 pub mod command;
 pub mod event;
+pub mod message;
 pub mod metadata;
 pub mod test;
 pub mod version;
-
-use serde::{Deserialize, Serialize};
-
-use crate::metadata::Metadata;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Message<T> {
-    pub payload: T,
-    pub metadata: Metadata,
-}
-
-impl<T> Message<T> {
-    pub fn with_metadata<F>(mut self, f: F) -> Self
-    where
-        F: Fn(Metadata) -> Metadata,
-    {
-        self.metadata = f(self.metadata);
-        self
-    }
-}
-
-impl<T> From<T> for Message<T> {
-    fn from(payload: T) -> Self {
-        Message {
-            payload,
-            metadata: Metadata::default(),
-        }
-    }
-}
-
-impl<T> PartialEq for Message<T>
-where
-    T: PartialEq,
-{
-    fn eq(&self, other: &Message<T>) -> bool {
-        self.payload == other.payload
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn message_with_metadata_does_not_affect_equality() {
-        let message = Message {
-            payload: "hello",
-            metadata: Metadata::default(),
-        };
-
-        let new_message = message.clone().with_metadata(|metadata| {
-            metadata
-                .add_string("hello_world".to_owned(), "test".to_owned())
-                .add_integer("test_number".to_owned(), 1)
-        });
-
-        println!("Message: {:?}", message);
-        println!("New message: {:?}", new_message);
-
-        // Metadata does not affect equality of message.
-        assert_eq!(message, new_message);
-    }
-}

--- a/eventually/src/message.rs
+++ b/eventually/src/message.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+
+use crate::metadata::Metadata;
+
+pub trait Payload {
+    fn name(&self) -> &'static str;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message<T>
+where
+    T: Payload,
+{
+    pub payload: T,
+    pub metadata: Metadata,
+}
+
+impl<T> Message<T>
+where
+    T: Payload,
+{
+    pub fn with_metadata<F>(mut self, f: F) -> Self
+    where
+        F: Fn(Metadata) -> Metadata,
+    {
+        self.metadata = f(self.metadata);
+        self
+    }
+}
+
+impl<T> From<T> for Message<T>
+where
+    T: Payload,
+{
+    fn from(payload: T) -> Self {
+        Message {
+            payload,
+            metadata: Metadata::default(),
+        }
+    }
+}
+
+impl<T> PartialEq for Message<T>
+where
+    T: Payload + PartialEq,
+{
+    fn eq(&self, other: &Message<T>) -> bool {
+        self.payload == other.payload
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) struct StringPayload(pub(crate) &'static str);
+
+    impl Payload for StringPayload {
+        fn name(&self) -> &'static str {
+            "string_payload"
+        }
+    }
+
+    #[test]
+    fn message_with_metadata_does_not_affect_equality() {
+        let message = Message {
+            payload: StringPayload("hello"),
+            metadata: Metadata::default(),
+        };
+
+        let new_message = message.clone().with_metadata(|metadata| {
+            metadata
+                .add_string("hello_world".to_owned(), "test".to_owned())
+                .add_integer("test_number".to_owned(), 1)
+        });
+
+        println!("Message: {:?}", message);
+        println!("New message: {:?}", new_message);
+
+        // Metadata does not affect equality of message.
+        assert_eq!(message, new_message);
+    }
+}


### PR DESCRIPTION
To pass down the name of Commands and Domain Events to potential Event Stores that use them, a `message::Payload` trait has been introduced.

The trait requires a `Message` inner payload to implement a `fn name(&self) -> &'static str` method to return its name.

What's more, this PR also modifies the `aggregate::Root` trait, which is now requiring `Borrow<Context>` and `BorrowMut<Context>` to cover the previous `fn ctx(&self) -> &Context` and `fn ctx_mut(&mut self) -> &mut Context` functions.