### PR TITLE
[v0.5.0] refactor: rename message::Payload to Message and Message to Envelope

### DIFF
--- a/eventually/src/event.rs
+++ b/eventually/src/event.rs
@@ -9,20 +9,19 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     message,
-    message::Message,
     version::{ConflictError, Version},
 };
 
 /// An Event is a [Message] carring the information about a Domain Event,
 /// an occurrence in the system lifetime that is relevant for the Domain
 /// that is being implemented.
-pub type Event<T> = Message<T>;
+pub type Envelope<T> = message::Envelope<T>;
 
 /// An [Event] that has been persisted to the Event [Store].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Persisted<Id, Evt>
 where
-    Evt: message::Payload,
+    Evt: message::Message,
 {
     /// The id of the Event Stream the persisted Event belongs to.
     pub stream_id: Id,
@@ -36,7 +35,7 @@ where
     pub version: Version,
 
     /// The actual Domain Event carried by this envelope.
-    pub payload: Event<Evt>,
+    pub event: Envelope<Evt>,
 }
 
 /// Specifies the slice of the Event Stream to select when calling [`Store::stream`].
@@ -81,7 +80,7 @@ pub trait Store: Send + Sync {
 
     /// The type containing all Domain Events recorded by the Event Store.
     /// Typically, this parameter should be an `enum`.
-    type Event: message::Payload + Send + Sync;
+    type Event: message::Message + Send + Sync;
 
     /// The error type returned by the Store during a [`stream`] call.
     type StreamError: Send + Sync;
@@ -107,6 +106,6 @@ pub trait Store: Send + Sync {
         &self,
         id: Self::StreamId,
         version_check: StreamVersionExpected,
-        events: Vec<Event<Self::Event>>,
+        events: Vec<Envelope<Self::Event>>,
     ) -> Result<Version, Self::AppendError>;
 }

--- a/eventually/src/message.rs
+++ b/eventually/src/message.rs
@@ -2,22 +2,22 @@ use serde::{Deserialize, Serialize};
 
 use crate::metadata::Metadata;
 
-pub trait Payload {
+pub trait Message {
     fn name(&self) -> &'static str;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Message<T>
+pub struct Envelope<T>
 where
-    T: Payload,
+    T: Message,
 {
-    pub payload: T,
+    pub message: T,
     pub metadata: Metadata,
 }
 
-impl<T> Message<T>
+impl<T> Envelope<T>
 where
-    T: Payload,
+    T: Message,
 {
     #[must_use]
     pub fn with_metadata<F>(mut self, f: F) -> Self
@@ -29,24 +29,24 @@ where
     }
 }
 
-impl<T> From<T> for Message<T>
+impl<T> From<T> for Envelope<T>
 where
-    T: Payload,
+    T: Message,
 {
-    fn from(payload: T) -> Self {
-        Message {
-            payload,
+    fn from(message: T) -> Self {
+        Envelope {
+            message,
             metadata: Metadata::default(),
         }
     }
 }
 
-impl<T> PartialEq for Message<T>
+impl<T> PartialEq for Envelope<T>
 where
-    T: Payload + PartialEq,
+    T: Message + PartialEq,
 {
-    fn eq(&self, other: &Message<T>) -> bool {
-        self.payload == other.payload
+    fn eq(&self, other: &Envelope<T>) -> bool {
+        self.message == other.message
     }
 }
 
@@ -55,9 +55,9 @@ pub(crate) mod tests {
     use super::*;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub(crate) struct StringPayload(pub(crate) &'static str);
+    pub(crate) struct StringMessage(pub(crate) &'static str);
 
-    impl Payload for StringPayload {
+    impl Message for StringMessage {
         fn name(&self) -> &'static str {
             "string_payload"
         }
@@ -65,8 +65,8 @@ pub(crate) mod tests {
 
     #[test]
     fn message_with_metadata_does_not_affect_equality() {
-        let message = Message {
-            payload: StringPayload("hello"),
+        let message = Envelope {
+            message: StringMessage("hello"),
             metadata: Metadata::default(),
         };
 


### PR DESCRIPTION
As the title says, this PR renames `message::Payload` trait into `message::Message`, and `message::Message` into `message::Envelope`

