### PR TITLE
[v0.5.0][eventually] refactor: use by-value methods for command_handler::Scenario API

### DIFF
--- a/eventually/src/command.rs
+++ b/eventually/src/command.rs
@@ -144,82 +144,86 @@ mod test_user_domain {
 
     #[tokio::test]
     async fn it_creates_a_new_user_successfully() {
-        test::command_handler::Scenario::when(command::Envelope::from(CreateUser {
-            email: "test@test.com".to_owned(),
-            password: "not-a-secret".to_owned(),
-        }))
-        .then(vec![event::Persisted {
-            stream_id: "test@test.com".to_owned(),
-            version: 1,
-            event: event::Envelope::from(UserEvent::WasCreated {
+        test::command_handler::Scenario
+            .when(command::Envelope::from(CreateUser {
                 email: "test@test.com".to_owned(),
                 password: "not-a-secret".to_owned(),
-            }),
-        }])
-        .assert_on(|event_store| {
-            CreateUserHandler(aggregate::EventSourcedRepository::from(event_store))
-        })
-        .await;
+            }))
+            .then(vec![event::Persisted {
+                stream_id: "test@test.com".to_owned(),
+                version: 1,
+                event: event::Envelope::from(UserEvent::WasCreated {
+                    email: "test@test.com".to_owned(),
+                    password: "not-a-secret".to_owned(),
+                }),
+            }])
+            .assert_on(|event_store| {
+                CreateUserHandler(aggregate::EventSourcedRepository::from(event_store))
+            })
+            .await;
     }
 
     #[tokio::test]
     async fn it_fails_to_create_an_user_if_it_still_exists() {
-        test::command_handler::Scenario::given(vec![event::Persisted {
-            stream_id: "test@test.com".to_owned(),
-            version: 1,
-            event: event::Envelope::from(UserEvent::WasCreated {
+        test::command_handler::Scenario
+            .given(vec![event::Persisted {
+                stream_id: "test@test.com".to_owned(),
+                version: 1,
+                event: event::Envelope::from(UserEvent::WasCreated {
+                    email: "test@test.com".to_owned(),
+                    password: "not-a-secret".to_owned(),
+                }),
+            }])
+            .when(command::Envelope::from(CreateUser {
                 email: "test@test.com".to_owned(),
                 password: "not-a-secret".to_owned(),
-            }),
-        }])
-        .when(command::Envelope::from(CreateUser {
-            email: "test@test.com".to_owned(),
-            password: "not-a-secret".to_owned(),
-        }))
-        .then_fails()
-        .assert_on(|event_store| {
-            CreateUserHandler(aggregate::EventSourcedRepository::from(event_store))
-        })
-        .await;
+            }))
+            .then_fails()
+            .assert_on(|event_store| {
+                CreateUserHandler(aggregate::EventSourcedRepository::from(event_store))
+            })
+            .await;
     }
 
     #[tokio::test]
     async fn it_updates_the_password_of_an_existing_user() {
-        test::command_handler::Scenario::given(vec![event::Persisted {
-            stream_id: "test@test.com".to_owned(),
-            version: 1,
-            event: event::Envelope::from(UserEvent::WasCreated {
+        test::command_handler::Scenario
+            .given(vec![event::Persisted {
+                stream_id: "test@test.com".to_owned(),
+                version: 1,
+                event: event::Envelope::from(UserEvent::WasCreated {
+                    email: "test@test.com".to_owned(),
+                    password: "not-a-secret".to_owned(),
+                }),
+            }])
+            .when(command::Envelope::from(ChangeUserPassword {
                 email: "test@test.com".to_owned(),
-                password: "not-a-secret".to_owned(),
-            }),
-        }])
-        .when(command::Envelope::from(ChangeUserPassword {
-            email: "test@test.com".to_owned(),
-            password: "new-password".to_owned(),
-        }))
-        .then(vec![event::Persisted {
-            stream_id: "test@test.com".to_owned(),
-            version: 2,
-            event: event::Envelope::from(UserEvent::PasswordWasChanged {
                 password: "new-password".to_owned(),
-            }),
-        }])
-        .assert_on(|event_store| {
-            ChangeUserPasswordHandler(aggregate::EventSourcedRepository::from(event_store))
-        })
-        .await;
+            }))
+            .then(vec![event::Persisted {
+                stream_id: "test@test.com".to_owned(),
+                version: 2,
+                event: event::Envelope::from(UserEvent::PasswordWasChanged {
+                    password: "new-password".to_owned(),
+                }),
+            }])
+            .assert_on(|event_store| {
+                ChangeUserPasswordHandler(aggregate::EventSourcedRepository::from(event_store))
+            })
+            .await;
     }
 
     #[tokio::test]
     async fn it_fails_to_update_the_password_if_the_user_does_not_exist() {
-        test::command_handler::Scenario::when(command::Envelope::from(ChangeUserPassword {
-            email: "test@test.com".to_owned(),
-            password: "new-password".to_owned(),
-        }))
-        .then_fails()
-        .assert_on(|event_store| {
-            ChangeUserPasswordHandler(aggregate::EventSourcedRepository::from(event_store))
-        })
-        .await;
+        test::command_handler::Scenario
+            .when(command::Envelope::from(ChangeUserPassword {
+                email: "test@test.com".to_owned(),
+                password: "new-password".to_owned(),
+            }))
+            .then_fails()
+            .assert_on(|event_store| {
+                ChangeUserPasswordHandler(aggregate::EventSourcedRepository::from(event_store))
+            })
+            .await;
     }
 }

--- a/eventually/src/test/command_handler.rs
+++ b/eventually/src/test/command_handler.rs
@@ -13,7 +13,7 @@ impl Scenario {
     /// Sets the precondition state of the system for the [Scenario], which
     /// is expressed by a list of Domain [Event]s in an Event-sourced system.
     #[must_use]
-    pub fn given<Id, Evt>(events: Vec<event::Persisted<Id, Evt>>) -> ScenarioGiven<Id, Evt>
+    pub fn given<Id, Evt>(self, events: Vec<event::Persisted<Id, Evt>>) -> ScenarioGiven<Id, Evt>
     where
         Evt: message::Message,
     {
@@ -28,7 +28,7 @@ impl Scenario {
     /// Scenario::given(vec![]).when(...)
     /// ```
     #[must_use]
-    pub fn when<Id, Evt, Cmd>(command: command::Envelope<Cmd>) -> ScenarioWhen<Id, Evt, Cmd>
+    pub fn when<Id, Evt, Cmd>(self, command: command::Envelope<Cmd>) -> ScenarioWhen<Id, Evt, Cmd>
     where
         Evt: message::Message,
         Cmd: message::Message,


### PR DESCRIPTION
The current API for `eventually::test::command_handler::Scenario` uses static methods, which look somewhat like this:
```rust
eventually::test::command_handler::Scenario::given(vec![
    // ...
])
```

This PR refactors this API by changing those methods to take `self`, resulting in the following API:
```rust
eventually::test::command_handler::Scenario
    .given(vec![
        // ...
    ])
    .when(...)
    .then(...)
    .assert_on(...)
```