### PR TITLE
fix(.github): add protoc to generate docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,11 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout sources
         uses: actions/checkout@v3
 


### PR DESCRIPTION
With the previous merge of #231 and the update of `tonic`, the Generate Docs pipeline is now failing due to missing `protoc`.

This PR fixes the issue by adding `protoc` during the action container setup steps.
