### PR TITLE
update coverage workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,31 +89,31 @@ jobs:
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           profile: minimal
           override: true
-          components: rustfmt
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: --workspace --all-features
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run llvm-cov
+        run: cargo llvm-cov --all-features --doctests --workspace --lcov --output-path lcov.info
         env:
           DATABASE_URL: postgres://eventually:password@localhost:5432/eventually?sslmode=disable
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
+          files: lcov.info
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report
-          path: cobertura.xml
+          path: lcov.info
 
   formatting:
     name: Rustfmt Check


### PR DESCRIPTION
`llvm-cov` is better maintained, and supports doc-tests coverage