### PR TITLE
fix(eventually-postgres): flaky integration test for event_store.rs

### DIFF
--- a/eventually-postgres/src/event.rs
+++ b/eventually-postgres/src/event.rs
@@ -35,9 +35,9 @@ pub enum StreamError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum AppendError {
-    #[error("conflict error detected: {0})")]
+    #[error("conflict error detected: {0}")]
     Conflict(#[source] version::ConflictError),
-    #[error("concurrent update detected, represented as a conflict error: {0})")]
+    #[error("concurrent update detected, represented as a conflict error: {0}")]
     Concurrency(#[source] version::ConflictError),
     #[error("failed to begin transaction: {0}")]
     BeginTransaction(#[source] sqlx::Error),

--- a/eventually-postgres/tests/event_store.rs
+++ b/eventually-postgres/tests/event_store.rs
@@ -182,15 +182,11 @@ async fn it_handles_concurrent_writes_to_the_same_stream() {
 
     match result {
         (Ok(_), Err(err)) | (Err(err), Ok(_)) => {
-            let expected_err = event::AppendError::Concurrency(version::ConflictError {
-                expected: 0,
-                actual: 1,
-            });
-
-            let actual_err_msg = format!("{}", err);
-            let expected_err_msg = format!("{}", expected_err);
-
-            assert_eq!(expected_err_msg, actual_err_msg);
+            if let event::AppendError::Conflict(_) | event::AppendError::Concurrency(_) = err {
+                // This is the expected scenario :)
+            } else {
+                panic!("unexpected error, {:?}", err);
+            }
         }
         (first, second) => panic!(
             "invalid state detected, first: {:?}, second: {:?}",


### PR DESCRIPTION
- fix(event): remove trailing parenthesis from AppendError
- fix(tests/event_store): use if-let-else for result assertion in case of concurrency
