### PR TITLE
feat(examples): bare minimum "light switch" example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ members = [
 
     # Crates as examples
     "examples/bank-accounting",
+    "examples/light-switch",
 ]

--- a/eventually/src/aggregate/mod.rs
+++ b/eventually/src/aggregate/mod.rs
@@ -246,15 +246,15 @@ where
 #[derive(Debug, thiserror::Error)]
 pub enum RehydrateError<T, I> {
     /// Error returned during rehydration when the [Aggregate Root][Root]
-    /// is applying a Domain Event using [Aggregate::apply].
+    /// is applying a Domain Event using [`Aggregate::apply`].
     ///
     /// This usually implies the Event Stream for the [Aggregate]
     /// contains corrupted or unexpected data.
     #[error("failed to apply domain event while rehydrating aggregate: {0}")]
     Domain(#[source] T),
 
-    /// This error is returned by [Root::rehydrate_async] when the underlying
-    /// [futures::TryStream] has returned an error.
+    /// This error is returned by [`Root::rehydrate_async`] when the underlying
+    /// [`futures::TryStream`] has returned an error.
     #[error("failed to rehydrate aggregate from event stream: {0}")]
     Inner(#[source] I),
 }

--- a/eventually/src/aggregate/repository.rs
+++ b/eventually/src/aggregate/repository.rs
@@ -39,7 +39,7 @@ where
 /// All possible errors returned by [`Saver::save`].
 #[derive(Debug, thiserror::Error)]
 pub enum SaveError {
-    /// Error returned when [Saver::save] encounters a conflict error while saving the new Aggregate Root.
+    /// Error returned when [`Saver::save`] encounters a conflict error while saving the new Aggregate Root.
     #[error("failed to save aggregate root: {0}")]
     Conflict(#[from] version::ConflictError),
     /// Error returned when the [Saver] implementation has encountered an error.

--- a/eventually/src/command/test.rs
+++ b/eventually/src/command/test.rs
@@ -163,6 +163,6 @@ where
                 assert_eq!(events, recorded_events);
             },
             ScenarioThenCase::Fails => assert!(result.is_err()),
-        };
+        }
     }
 }

--- a/eventually/src/event/store.rs
+++ b/eventually/src/event/store.rs
@@ -33,7 +33,7 @@ where
 /// All possible error types returned by [`Appender::append`].
 #[derive(Debug, thiserror::Error)]
 pub enum AppendError {
-    /// Error returned when [Appender::append] encounters a conflict error
+    /// Error returned when [`Appender::append`] encounters a conflict error
     /// while appending the new Domain Events.
     #[error("failed to append new domain events: {0}")]
     Conflict(#[from] version::ConflictError),

--- a/examples/light-switch/Cargo.toml
+++ b/examples/light-switch/Cargo.toml
@@ -13,4 +13,3 @@ thiserror = { version = "2.0.11" }
 anyhow = "1.0.95"
 async-trait = "0.1.86"
 eventually = { features = ["serde-json"], path="../../eventually" }
-eventually-macros = { path="../../eventually-macros" }

--- a/examples/light-switch/Cargo.toml
+++ b/examples/light-switch/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "light_switch"
+version = "0.1.0"
+edition = "2021"
+readme = "README.md"
+publish = false
+
+[dependencies]
+serde = {version="1.0.217", features=["derive"]}
+serde_json = {version="1.0.137"}
+tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
+thiserror = { version = "2.0.11" }
+anyhow = "1.0.95"
+async-trait = "0.1.86"
+eventually = { features = ["serde-json"], path="../../eventually" }
+eventually-macros = { path="../../eventually-macros" }

--- a/examples/light-switch/README.md
+++ b/examples/light-switch/README.md
@@ -1,0 +1,8 @@
+# Example: Light Switch application
+
+This example application is a bare minimum example of the core functionality.
+Persistence is not enabled, nor is logging, nor any kind of user interface. It
+just starts, runs some commands, queries the final state and prints it.
+
+It models a "light switch". You can "install" the switch, then turn it "off" or
+"on" using commands. You can issue a query to get the current state of a switch.

--- a/examples/light-switch/src/application.rs
+++ b/examples/light-switch/src/application.rs
@@ -1,0 +1,23 @@
+use eventually::aggregate;
+
+use crate::domain::Lightswitch;
+pub type LightswitchRepo<S> = aggregate::EventSourcedRepository<Lightswitch, S>;
+
+#[derive(Clone)]
+pub struct LightswitchService<R>
+where
+    R: aggregate::Repository<Lightswitch>,
+{
+    pub light_switch_repository: R,
+}
+
+impl<R> From<R> for LightswitchService<R>
+where
+    R: aggregate::Repository<Lightswitch>,
+{
+    fn from(light_switch_repository: R) -> Self {
+        Self {
+            light_switch_repository,
+        }
+    }
+}

--- a/examples/light-switch/src/commands/install_light_switch.rs
+++ b/examples/light-switch/src/commands/install_light_switch.rs
@@ -1,0 +1,33 @@
+use async_trait::async_trait;
+use eventually::{aggregate, command, message};
+
+use crate::application::LightswitchService;
+use crate::domain::{Lightswitch, LightswitchId, LightswitchRoot};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallLightSwitch {
+    pub id: LightswitchId,
+}
+
+impl message::Message for InstallLightSwitch {
+    fn name(&self) -> &'static str {
+        "InstallLightSwitch"
+    }
+}
+
+#[async_trait]
+impl<R> command::Handler<InstallLightSwitch> for LightswitchService<R>
+where
+    R: aggregate::Repository<Lightswitch>,
+{
+    type Error = anyhow::Error;
+    async fn handle(
+        &self,
+        command: command::Envelope<InstallLightSwitch>,
+    ) -> Result<(), Self::Error> {
+        let command = command.message;
+        let mut light_switch = LightswitchRoot::install(command.id)?;
+        self.light_switch_repository.save(&mut light_switch).await?;
+        Ok(())
+    }
+}

--- a/examples/light-switch/src/commands/mod.rs
+++ b/examples/light-switch/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod install_light_switch;
+pub mod turn_light_switch_off;
+pub mod turn_light_switch_on;

--- a/examples/light-switch/src/commands/turn_light_switch_off.rs
+++ b/examples/light-switch/src/commands/turn_light_switch_off.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+use eventually::{aggregate, command, message};
+
+use crate::application::LightswitchService;
+use crate::domain::{Lightswitch, LightswitchId, LightswitchRoot};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnLightSwitchOff {
+    pub id: LightswitchId,
+}
+
+impl message::Message for TurnLightSwitchOff {
+    fn name(&self) -> &'static str {
+        "TurnLightSwitchOff"
+    }
+}
+
+#[async_trait]
+impl<R> command::Handler<TurnLightSwitchOff> for LightswitchService<R>
+where
+    R: aggregate::Repository<Lightswitch>,
+{
+    type Error = anyhow::Error;
+    async fn handle(
+        &self,
+        command: command::Envelope<TurnLightSwitchOff>,
+    ) -> Result<(), Self::Error> {
+        let command = command.message;
+        let mut root: LightswitchRoot = self.light_switch_repository.get(&command.id).await?.into();
+        let _ = root.turn_off(command.id)?;
+        self.light_switch_repository.save(&mut root).await?;
+        Ok(())
+    }
+}

--- a/examples/light-switch/src/commands/turn_light_switch_on.rs
+++ b/examples/light-switch/src/commands/turn_light_switch_on.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+use eventually::{aggregate, command, message};
+
+use crate::application::LightswitchService;
+use crate::domain::{Lightswitch, LightswitchId, LightswitchRoot};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnLightSwitchOn {
+    pub id: LightswitchId,
+}
+
+impl message::Message for TurnLightSwitchOn {
+    fn name(&self) -> &'static str {
+        "TurnLightSwitchOn"
+    }
+}
+
+#[async_trait]
+impl<R> command::Handler<TurnLightSwitchOn> for LightswitchService<R>
+where
+    R: aggregate::Repository<Lightswitch>,
+{
+    type Error = anyhow::Error;
+    async fn handle(
+        &self,
+        command: command::Envelope<TurnLightSwitchOn>,
+    ) -> Result<(), Self::Error> {
+        let command = command.message;
+        let mut root: LightswitchRoot = self.light_switch_repository.get(&command.id).await?.into();
+        let _ = root.turn_on(command.id)?;
+        self.light_switch_repository.save(&mut root).await?;
+        Ok(())
+    }
+}

--- a/examples/light-switch/src/domain.rs
+++ b/examples/light-switch/src/domain.rs
@@ -1,5 +1,4 @@
 use eventually::{aggregate, message};
-use eventually_macros::aggregate_root;
 
 pub type LightswitchId = String;
 
@@ -104,9 +103,31 @@ impl aggregate::Aggregate for Lightswitch {
     }
 }
 
-#[aggregate_root(Lightswitch)]
+// root
 #[derive(Debug, Clone)]
-pub struct LightswitchRoot;
+pub struct LightswitchRoot(aggregate::Root<Lightswitch>);
+
+impl From<eventually::aggregate::Root<Lightswitch>> for LightswitchRoot {
+    fn from(root: eventually::aggregate::Root<Lightswitch>) -> Self {
+        Self(root)
+    }
+}
+impl From<LightswitchRoot> for eventually::aggregate::Root<Lightswitch> {
+    fn from(value: LightswitchRoot) -> Self {
+        value.0
+    }
+}
+impl std::ops::Deref for LightswitchRoot {
+    type Target = eventually::aggregate::Root<Lightswitch>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl std::ops::DerefMut for LightswitchRoot {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 impl LightswitchRoot {
     pub fn install(id: LightswitchId) -> Result<Self, LightswitchError> {

--- a/examples/light-switch/src/domain.rs
+++ b/examples/light-switch/src/domain.rs
@@ -1,0 +1,135 @@
+use eventually::{aggregate, message};
+use eventually_macros::aggregate_root;
+
+pub type LightswitchId = String;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LightswitchError {
+    #[error("NotImplemented")]
+    NotImplemented,
+    #[error("Light switch is already on")]
+    AlreadyOn,
+    #[error("Light switch is already off")]
+    AlreadyOff,
+}
+
+// events
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Installed {
+    id: LightswitchId,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SwitchedOn {
+    id: LightswitchId,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SwitchedOff {
+    id: LightswitchId,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum LightswitchEvent {
+    Installed(Installed),
+    SwitchedOn(SwitchedOn),
+    SwitchedOff(SwitchedOff),
+}
+
+impl message::Message for LightswitchEvent {
+    fn name(&self) -> &'static str {
+        match self {
+            LightswitchEvent::SwitchedOn(_) => "SwitchedOn",
+            LightswitchEvent::SwitchedOff(_) => "SwitchedOff",
+            LightswitchEvent::Installed(_) => "Installed",
+        }
+    }
+}
+
+// aggregate
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum LightswitchState {
+    ON,
+    OFF,
+}
+
+#[derive(Debug, Clone)]
+pub struct Lightswitch {
+    id: LightswitchId,
+    state: LightswitchState,
+}
+
+impl aggregate::Aggregate for Lightswitch {
+    type Id = LightswitchId;
+    type Event = LightswitchEvent;
+    type Error = LightswitchError;
+
+    fn type_name() -> &'static str {
+        "Lightswitch"
+    }
+
+    fn aggregate_id(&self) -> &Self::Id {
+        &self.id
+    }
+
+    fn apply(state: Option<Self>, event: Self::Event) -> Result<Self, Self::Error> {
+        match state {
+            None => match event {
+                LightswitchEvent::Installed(installed) => Ok(Lightswitch {
+                    id: installed.id,
+                    state: LightswitchState::OFF,
+                }),
+                LightswitchEvent::SwitchedOn(_) | LightswitchEvent::SwitchedOff(_) => {
+                    Err(LightswitchError::NotImplemented)
+                },
+            },
+            Some(mut light_switch) => match event {
+                LightswitchEvent::Installed(_) => Err(LightswitchError::NotImplemented),
+                LightswitchEvent::SwitchedOn(_) => match light_switch.state {
+                    LightswitchState::ON => Err(LightswitchError::AlreadyOn),
+                    LightswitchState::OFF => {
+                        light_switch.state = LightswitchState::ON;
+                        Ok(light_switch)
+                    },
+                },
+                LightswitchEvent::SwitchedOff(_) => match light_switch.state {
+                    LightswitchState::ON => {
+                        light_switch.state = LightswitchState::OFF;
+                        Ok(light_switch)
+                    },
+                    LightswitchState::OFF => Err(LightswitchError::AlreadyOff),
+                },
+            },
+        }
+    }
+}
+
+#[aggregate_root(Lightswitch)]
+#[derive(Debug, Clone)]
+pub struct LightswitchRoot;
+
+impl LightswitchRoot {
+    pub fn install(id: LightswitchId) -> Result<Self, LightswitchError> {
+        aggregate::Root::<Lightswitch>::record_new(
+            LightswitchEvent::Installed(Installed { id }).into(),
+        )
+        .map(Self)
+    }
+    pub fn turn_on(&mut self, id: LightswitchId) -> Result<(), LightswitchError> {
+        if self.state == LightswitchState::ON {
+            return Err(LightswitchError::AlreadyOn);
+        }
+
+        self.record_that(LightswitchEvent::SwitchedOn(SwitchedOn { id }).into())
+    }
+    pub fn turn_off(&mut self, id: LightswitchId) -> Result<(), LightswitchError> {
+        if self.state == LightswitchState::OFF {
+            return Err(LightswitchError::AlreadyOff);
+        }
+
+        self.record_that(LightswitchEvent::SwitchedOff(SwitchedOff { id }).into())
+    }
+    pub fn get_switch_state(&self) -> Result<LightswitchState, LightswitchError> {
+        Ok(self.state.clone())
+    }
+}

--- a/examples/light-switch/src/main.rs
+++ b/examples/light-switch/src/main.rs
@@ -1,0 +1,48 @@
+mod application;
+mod commands;
+mod domain;
+mod queries;
+use anyhow;
+use application::{LightswitchRepo, LightswitchService};
+use commands::install_light_switch::InstallLightSwitch;
+use commands::turn_light_switch_off::TurnLightSwitchOff;
+use commands::turn_light_switch_on::TurnLightSwitchOn;
+use domain::{LightswitchEvent, LightswitchId};
+use eventually::{command, event, query};
+use queries::get_switch_state::GetSwitchState;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let store = event::store::InMemory::<LightswitchId, LightswitchEvent>::default();
+    let repo = LightswitchRepo::from(store.clone());
+    let svc = LightswitchService::from(repo);
+
+    let cmd = InstallLightSwitch {
+        id: "Switch1".to_string(),
+    }
+    .into();
+    let _ = command::Handler::handle(&svc, cmd).await?;
+    println!("Installed Switch1");
+
+    let cmd = TurnLightSwitchOn {
+        id: "Switch1".to_string(),
+    }
+    .into();
+    let _ = command::Handler::handle(&svc, cmd).await?;
+    println!("Turned Switch1 ON");
+
+    let cmd = TurnLightSwitchOff {
+        id: "Switch1".to_string(),
+    }
+    .into();
+    let _ = command::Handler::handle(&svc, cmd).await?;
+    println!("Turned Switch1 OFF");
+
+    let query = GetSwitchState {
+        id: "Switch1".to_string(),
+    }
+    .into();
+    let state = query::Handler::handle(&svc, query).await?;
+    println!("Switch1 is currently: {:?}", state);
+    Ok(())
+}

--- a/examples/light-switch/src/queries/get_switch_state.rs
+++ b/examples/light-switch/src/queries/get_switch_state.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+use eventually::{aggregate, message, query};
+
+use crate::application::LightswitchService;
+use crate::domain::{Lightswitch, LightswitchId, LightswitchRoot, LightswitchState};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetSwitchState {
+    pub id: LightswitchId,
+}
+
+impl message::Message for GetSwitchState {
+    fn name(&self) -> &'static str {
+        "GetSwitch"
+    }
+}
+
+#[async_trait]
+impl<R> query::Handler<GetSwitchState> for LightswitchService<R>
+where
+    R: aggregate::Repository<Lightswitch>,
+{
+    type Error = anyhow::Error;
+    type Output = LightswitchState;
+
+    async fn handle(
+        &self,
+        query: query::Envelope<GetSwitchState>,
+    ) -> Result<LightswitchState, Self::Error> {
+        let query = query.message;
+        let root: LightswitchRoot = self.light_switch_repository.get(&query.id).await?.into();
+        let s = root.get_switch_state()?;
+        Ok(s)
+    }
+}

--- a/examples/light-switch/src/queries/mod.rs
+++ b/examples/light-switch/src/queries/mod.rs
@@ -1,0 +1,1 @@
+pub mod get_switch_state;


### PR DESCRIPTION
This example application is a bare minimum example of the core functionality. Persistence is not enabled, nor is logging, nor any kind of user interface. It just starts, runs some commands, queries the final state and prints it.

It models a "light switch". You can "install" the switch, then turn it "off" or "on" using commands. You can issue a query to get the current state of a switch.